### PR TITLE
Expand error message to point to alternatives

### DIFF
--- a/tests/test_in_process.py
+++ b/tests/test_in_process.py
@@ -40,7 +40,7 @@ def assert_hotfix_functional(capsys, func, *args, **kwargs):
         expected_schema = pa.schema([pa.field('ext', pa.null())])
         assert table.schema.equals(expected_schema, check_metadata=False)
     else:
-        expected = "forbidden deserialization of 'arrow.py_extension_type'"
+        expected = "Disallowed deserialization of 'arrow.py_extension_type'"
         with pytest.raises(RuntimeError, match=expected):
             func(*args, **kwargs)
     captured = capsys.readouterr()


### PR DESCRIPTION
This expands the error message to 1) mention how to still read the file if you know it is trusted, and 2) point users to use ExtensionType instead of PyExtensionType. 
(similarly as I did for pandas. Although if you actively installed pyarrow_hotfix, you are probably already aware of it and it's less important to have this expanded message).

@pitrou would you be OK with something like this? (would still need to update the tests that check the message)