### PR TITLE
Don't fail if pyarrow is not installed.

### DIFF
--- a/src/pyarrow_hotfix/__init__.py
+++ b/src/pyarrow_hotfix/__init__.py
@@ -27,7 +27,7 @@ def install():
     import atexit
     try:
         import pyarrow as pa
-    except ImportError:
+    except ModuleNotFoundError:
         # Not installed; nothing to do here.
         return
 
@@ -76,7 +76,7 @@ def uninstall():
     import atexit
     try:
         import pyarrow as pa
-    except ImportError:
+    except ModuleNotFoundError:
         # Not installed; nothing to do here.
         return
 

--- a/src/pyarrow_hotfix/__init__.py
+++ b/src/pyarrow_hotfix/__init__.py
@@ -25,7 +25,11 @@ for more details.
 
 def install():
     import atexit
-    import pyarrow as pa
+    try:
+        import pyarrow as pa
+    except ImportError:
+        # Not installed; nothing to do here.
+        return
 
     if not hasattr(pa, "ExtensionType"):
         # Unsupported PyArrow version?
@@ -70,7 +74,11 @@ def install():
 
 def uninstall():
     import atexit
-    import pyarrow as pa
+    try:
+        import pyarrow as pa
+    except ImportError:
+        # Not installed; nothing to do here.
+        return
 
     if not hasattr(pa, "ExtensionType"):
         # Unsupported PyArrow version?

--- a/src/pyarrow_hotfix/__init__.py
+++ b/src/pyarrow_hotfix/__init__.py
@@ -22,12 +22,17 @@ See https://arrow.apache.org/docs/dev/python/extending_types.html#defining-exten
 for more details.
 """
 
+try:
+    _import_error = ModuleNotFoundError
+except NameError:
+    _import_error = ImportError  # ModuleNotFoundError unavailable in py3.5
+
 
 def install():
     import atexit
     try:
         import pyarrow as pa
-    except ModuleNotFoundError:
+    except _import_error:
         # Not installed; nothing to do here.
         return
 
@@ -76,7 +81,7 @@ def uninstall():
     import atexit
     try:
         import pyarrow as pa
-    except ModuleNotFoundError:
+    except _import_error:
         # Not installed; nothing to do here.
         return
 

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,8 +1,5 @@
-import os
 import subprocess
 import sys
-
-import pytest
 
 
 def assert_silent_subprocess(code):
@@ -66,5 +63,14 @@ def test_import_twice():
         del sys.modules['pyarrow_hotfix']
         del pyarrow_hotfix
         import pyarrow_hotfix
+        """
+    assert_silent_subprocess(code)
+
+def test_no_pyarrow():
+    code = """if 1:
+        import sys
+        sys.modules['pyarrow'] = None  # causes ModuleNotFoundError
+        import pyarrow_hotfix
+        pyarrow_hotfix.uninstall()
         """
     assert_silent_subprocess(code)


### PR DESCRIPTION
Since this doesn't directly depend upon pyarrow, it is possible that some end-user code does `import pyarrow_hotfix` as a defense mechanism, despite not needing `pyarrow_hotfix` itself. If this happens, it should not be a failure.

---

This is a simple proposal to take or leave; it also may be reasonable to add a warning that Arrow isn’t installed.