### PR TITLE
Update for pyarrow 21.0.0

### DIFF
--- a/src/pyarrow_hotfix/__init__.py
+++ b/src/pyarrow_hotfix/__init__.py
@@ -40,6 +40,10 @@ def install():
         # Unsupported PyArrow version?
         return
 
+    if not hasattr(pa, "PyExtensionType"):
+        # 21.0.0 <= PyArrow
+        return
+
     if getattr(pa, "_hotfix_installed", False):
         return
 
@@ -62,7 +66,7 @@ def install():
             )
 
     if hasattr(pa, "unregister_extension_type"):
-        # 0.15.0 <= PyArrow
+        # 0.15.0 <= PyArrow < 21.0.0
         pa.unregister_extension_type("arrow.py_extension_type")
         pa.register_extension_type(ForbiddenExtensionType(pa.null(),
                                                           "arrow.py_extension_type"))
@@ -89,11 +93,15 @@ def uninstall():
         # Unsupported PyArrow version?
         return
 
+    if not hasattr(pa, "PyExtensionType"):
+        # 21.0.0 <= PyArrow
+        return
+
     if not getattr(pa, "_hotfix_installed", False):
         return
 
     if hasattr(pa, "unregister_extension_type"):
-        # 0.15.0 <= PyArrow
+        # 0.15.0 <= PyArrow < 21.0.0
         pa.unregister_extension_type("arrow.py_extension_type")
         pa.lib._register_py_extension_type()
     elif hasattr(pa.lib, "_register_py_extension_type"):

--- a/src/pyarrow_hotfix/__init__.py
+++ b/src/pyarrow_hotfix/__init__.py
@@ -40,10 +40,6 @@ def install():
         # Unsupported PyArrow version?
         return
 
-    if not hasattr(pa, "PyExtensionType"):
-        # 21.0.0 <= PyArrow
-        return
-
     if getattr(pa, "_hotfix_installed", False):
         return
 
@@ -66,9 +62,13 @@ def install():
             )
 
     if hasattr(pa, "unregister_extension_type"):
-        # 0.15.0 <= PyArrow < 21.0.0
-        pa.unregister_extension_type("arrow.py_extension_type")
-        pa.register_extension_type(ForbiddenExtensionType(pa.null(),
+        if not hasattr(pa, "PyExtensionType"):
+            # 21.0.0 <= PyArrow
+            return
+        else:
+            # 0.15.0 <= PyArrow < 21.0.0
+            pa.unregister_extension_type("arrow.py_extension_type")
+            pa.register_extension_type(ForbiddenExtensionType(pa.null(),
                                                           "arrow.py_extension_type"))
     elif hasattr(pa.lib, "_unregister_py_extension_type"):
         # 0.14.1 <= PyArrow < 0.15.0
@@ -93,17 +93,17 @@ def uninstall():
         # Unsupported PyArrow version?
         return
 
-    if not hasattr(pa, "PyExtensionType"):
-        # 21.0.0 <= PyArrow
-        return
-
     if not getattr(pa, "_hotfix_installed", False):
         return
 
     if hasattr(pa, "unregister_extension_type"):
-        # 0.15.0 <= PyArrow < 21.0.0
-        pa.unregister_extension_type("arrow.py_extension_type")
-        pa.lib._register_py_extension_type()
+        if not hasattr(pa, "PyExtensionType"):
+            # 21.0.0 <= PyArrow
+            return
+        else:
+            # 0.15.0 <= PyArrow < 21.0.0
+            pa.unregister_extension_type("arrow.py_extension_type")
+            pa.lib._register_py_extension_type()
     elif hasattr(pa.lib, "_register_py_extension_type"):
         # 0.14.1 <= PyArrow < 0.15.0
         pa.lib._register_py_extension_type()

--- a/tests/test_in_process.py
+++ b/tests/test_in_process.py
@@ -35,7 +35,7 @@ def uninstalled_hotfix():
 
 
 def assert_hotfix_functional(capsys, func, *args, **kwargs):
-    if pa_version < (0, 15):
+    if pa_version < (0, 15) or pa_version >= (21, 0):
         table = func(*args, **kwargs)
         expected_schema = pa.schema([pa.field('ext', pa.null())])
         assert table.schema.equals(expected_schema, check_metadata=False)


### PR DESCRIPTION
In PyArrow version 21.0.0 `PyExtensionType` will be removed, see https://github.com/apache/arrow/pull/46199. We need to update the checks in `__init__` so that the hotfix doesn't break with future pyarrow versions.